### PR TITLE
[🐸 Frogbot] Update version of org.apache.commons:commons-compress to 1.26.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
             <!-- Problematic version from log: 1.25.0 (fix attempted for 1.26.0) -->
-            <version>1.25.0</version>
+            <version>1.26.0</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION


[comment]: <> (FrogbotReviewComment)

<div align='center'>

[![🚨 This automated pull request was created by Frogbot and fixes the below:](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>



### 📦 Vulnerable Dependencies

<div align='center'>

| Severity                | ID                  | Contextual Analysis                  | Direct Dependencies                  | Impacted Dependency                  | Fixed Versions                  |
| :---------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: |
| ![medium](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableMediumSeverity.png)<br>  Medium | CVE-2024-25710 | Not Covered | org.apache.commons:commons-compress:1.25.0<br>org.jfrog.test:multi1:3.7-SNAPSHOT | org.apache.commons:commons-compress 1.25.0 | [1.26.0] |

</div>


### 🔖 Details



### Vulnerability Details
|                 |                   |
| --------------------- | :-----------------------------------: |
| **Contextual Analysis:** | Not Covered |
| **Direct Dependencies:** | org.apache.commons:commons-compress:1.25.0, org.jfrog.test:multi1:3.7-SNAPSHOT |
| **Impacted Dependency:** | org.apache.commons:commons-compress:1.25.0 |
| **Fixed Versions:** | [1.26.0] |
| **CVSS V3:** | 5.5 |

Loop with Unreachable Exit Condition ('Infinite Loop') vulnerability in Apache Commons Compress.This issue affects Apache Commons Compress: from 1.3 through 1.25.0.

Users are recommended to upgrade to version 1.26.0 which fixes the issue.


---
<div align='center'>

[🐸 JFrog Frogbot](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>
